### PR TITLE
fix(registry): replace undefined st-md utility with st-body-md

### DIFF
--- a/apps/docs/registry/ui/accordion.tsx
+++ b/apps/docs/registry/ui/accordion.tsx
@@ -67,7 +67,7 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Panel
       data-slot="accordion-content"
-      className="overflow-hidden st-md data-open:animate-accordion-down data-closed:animate-accordion-up"
+      className="overflow-hidden st-body-md data-open:animate-accordion-down data-closed:animate-accordion-up"
       {...props}
     >
       <div

--- a/apps/docs/registry/ui/empty.tsx
+++ b/apps/docs/registry/ui/empty.tsx
@@ -83,7 +83,7 @@ function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="empty-content"
       className={cn(
-        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 st-md text-balance",
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 st-body-md text-balance",
         className
       )}
       {...props}

--- a/apps/docs/registry/ui/sidebar.tsx
+++ b/apps/docs/registry/ui/sidebar.tsx
@@ -631,7 +631,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 const sidebarMenuButtonVariants = cva(
   [
     // Base
-    "flex items-center overflow-hidden rounded-lg p-2 text-left st-md-compact ring-ring outline-hidden transition-[width,height,padding] hover:bg-surface-hover hover:text-text focus-visible:ring-ring active:text-text",
+    "flex items-center overflow-hidden rounded-lg p-2 text-left st-body-md-compact ring-ring outline-hidden transition-[width,height,padding] hover:bg-surface-hover hover:text-text focus-visible:ring-ring active:text-text",
     // Sizing
     "w-full gap-2",
     // Variants — adjacent action button reserves space


### PR DESCRIPTION
The st-md and st-md-compact classes are not defined in globals.css — only st-body-{sm,md,lg} and their -strong/-compact variants exist.